### PR TITLE
Add support for handling of Sympy number symbols

### DIFF
--- a/pycollo/node.py
+++ b/pycollo/node.py
@@ -45,8 +45,8 @@ class Cached(type):
 class Node(metaclass=Cached):
 
 	def __init__(self, key, graph, *, value=None, equation=None):
-		self.key = sym.sympify(key)
 		self.graph = graph
+		self.key = key
 		self._operation = None
 		self._set_node_type_stateful_object()
 		self._associate_new_node_with_graph()
@@ -71,6 +71,16 @@ class Node(metaclass=Cached):
 	def _associate_new_node_with_graph(self):
 		self.symbol = self._type._create_or_get_new_node_symbol(self)
 		self._type._graph_node_group(self)[self.symbol] = self
+
+	@property
+	def key(self):
+		return self._key
+	
+	@key.setter
+	def key(self, key):
+		self._key = sym.sympify(key)
+		if self.key.is_NumberSymbol:
+			self.graph._user_constants.add(self.key)
 
 	@property
 	def child_nodes(self):
@@ -361,7 +371,10 @@ class ConstantNode(RootNode):
 
 	@staticmethod
 	def _set_value(node_instance, value):
-		return float(value)
+		try:
+			return float(value)
+		except TypeError:
+			return float(node_instance.key)
 
 	@staticmethod
 	def _str(node_instance):


### PR DESCRIPTION
Fixes a bug where production of the expression graph fails if a Sympy number symbol (e.g. `sym.pi`) is encountered. An additional check during node initialisation is conducted to see whether `is_NumberSymbol` for a node key is `True` after sympification. If this is the case then the symbol is added to the set of user constants. This then causes it to be treated as a `ConstantNode` object rather than an `IntermediateNode`. A further amendment to the `ConstantNode._set_value` static method is applied which defaults to trying to convert to symbol key to a float in the scenario where attempting to convert the supplied value argument to a float raises as `TypeError`.