### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include setup.py
+include LICENSE
+include CHANGELOG.rst
+include README.rst
+include requirements.txt
+recursive-include pyproprop .*py
+recursive-include tests *.py *.txt
+recursive-include docs Makefile *.bat *.rst *.py *.txt


### PR DESCRIPTION
This PR adds a MANIFEST.in to ensure that the `requirements.txt`, `tests/`, `docs/` etc. are included in the source distribution. This fixes a bug prohibiting Pycollo being published on conda-forge (see here: https://github.com/conda-forge/staged-recipes/pull/15292).