### PR TITLE
Fix mistake in cart pole example

### DIFF
--- a/examples/cart_pole_swing_up/cart_pole_swing_up.py
+++ b/examples/cart_pole_swing_up/cart_pole_swing_up.py
@@ -74,7 +74,7 @@ problem.auxiliary_data = {g: 9.81,
 problem.initialise()
 problem.solve()
 
-time_solution = problem.solution.tau[0] + 1.0
+time_solution = problem.solution._time_[0]
 position_solution = problem.solution.state[0][0]
 angle_solution = problem.solution.state[0][1]
 control_solution = problem.solution.control[0][0]

--- a/examples/cart_pole_swing_up/cart_pole_swing_up.py
+++ b/examples/cart_pole_swing_up/cart_pole_swing_up.py
@@ -74,7 +74,7 @@ problem.auxiliary_data = {g: 9.81,
 problem.initialise()
 problem.solve()
 
-time_solution = 0.5 * problem.solution.tau[0] + 0.5
+time_solution = problem.solution.tau[0] + 1.0
 position_solution = problem.solution.state[0][0]
 angle_solution = problem.solution.state[0][1]
 control_solution = problem.solution.control[0][0]


### PR DESCRIPTION
The `time_solution` variable in `examples/cart_pole_swing_up/cart_pole_swing_up.py` was across an incorrect domain. This PR corrects the mistake.