### PR TITLE
Allow `sympy.physics.mechanics.dynamicsymbols` to be used as state and control variables

### DIFF
--- a/pycollo/typing.py
+++ b/pycollo/typing.py
@@ -11,9 +11,9 @@ part of Pycollo.
 
 from typing import Iterable, NamedTuple, Optional, Tuple, Union
 
-import sympy as sym
+import sympy as sm
 
-SympyType = Union[sym.Symbol, sym.Expr]
+SympyType = Union[sm.Symbol, sm.Expr]
 """For Sympy symbols and expressions."""
 
 OptionalBoundsType = Optional[Iterable[Union[None, float, Iterable[float]]]]
@@ -22,8 +22,14 @@ OptionalBoundsType = Optional[Iterable[Union[None, float, Iterable[float]]]]
 OptionalExprsType = Union[None, SympyType, Iterable[SympyType]]
 """For user-supplied symbols/equations for functions."""
 
-OptionalSymsType = Union[None, sym.Symbol, Iterable[sym.Symbol]]
+OptionalSymsType = Union[
+    None,
+    sm.Symbol,
+    Iterable[sm.Symbol],
+    sm.backend.core.AppliedUndef,  # for sm.physics.mechanics.dynamicsymbols
+    Iterable[sm.backend.core.AppliedUndef],
+]
 """For user-supplied symbols for variables."""
 
-TupleSymsType = Union[Tuple[sym.Symbol, ...], NamedTuple]
+TupleSymsType = Union[Tuple[sm.Symbol, ...], NamedTuple]
 """For return values of varible properties."""

--- a/pycollo/typing.py
+++ b/pycollo/typing.py
@@ -12,6 +12,7 @@ part of Pycollo.
 from typing import Iterable, NamedTuple, Optional, Tuple, Union
 
 import sympy as sm
+from sympy.core.backend import AppliedUndef
 
 SympyType = Union[sm.Symbol, sm.Expr]
 """For Sympy symbols and expressions."""
@@ -26,8 +27,8 @@ OptionalSymsType = Union[
     None,
     sm.Symbol,
     Iterable[sm.Symbol],
-    sm.backend.core.AppliedUndef,  # for sm.physics.mechanics.dynamicsymbols
-    Iterable[sm.backend.core.AppliedUndef],
+    AppliedUndef,  # for sm.physics.mechanics.dynamicsymbols
+    Iterable[AppliedUndef],
 ]
 """For user-supplied symbols for variables."""
 

--- a/pycollo/utils.py
+++ b/pycollo/utils.py
@@ -55,7 +55,7 @@ def symbol_name(symbol):
     """
     if isinstance(symbol, ca.SX):
         return symbol.name()
-    elif isinstance(symbol, sym.Symbol):
+    elif isinstance(symbol, (sym.Symbol, sym.core.backend.AppliedUndef)):
         return symbol.name
     msg = f"Cannot get name for symbol of type {type(symbol)}."
     raise NotImplementedError(msg)

--- a/pycollo/utils.py
+++ b/pycollo/utils.py
@@ -182,7 +182,12 @@ def format_as_named_tuple(
         entries = iterable
     if use_named:
         if named_keys is None:
-            named_keys = [str(entry) for entry in entries]
+            named_keys = []
+            for entry in entries:
+                identifier = str(entry)
+                if not identifier.isidentifier() and identifier[-3:] == "(t)":
+                    identifier = identifier[:-3]
+                named_keys.append(identifier)
         NamedTuple = collections.namedtuple('NamedTuple', named_keys)
         formatted_entries = NamedTuple(*entries)
     else:

--- a/pycollo/utils.py
+++ b/pycollo/utils.py
@@ -4,6 +4,7 @@ from typing import Iterable, Mapping, NamedTuple, Optional
 import casadi as ca
 import numpy as np
 import sympy as sym
+from sympy.core.backend import AppliedUndef
 
 from .typing import OptionalSymsType, TupleSymsType
 
@@ -55,7 +56,7 @@ def symbol_name(symbol):
     """
     if isinstance(symbol, ca.SX):
         return symbol.name()
-    elif isinstance(symbol, (sym.Symbol, sym.core.backend.AppliedUndef)):
+    elif isinstance(symbol, (sym.Symbol, AppliedUndef)):
         return symbol.name
     msg = f"Cannot get name for symbol of type {type(symbol)}."
     raise NotImplementedError(msg)

--- a/tests/integration/test_brachistochrone.py
+++ b/tests/integration/test_brachistochrone.py
@@ -9,6 +9,7 @@ reference for this optimal control problem.
 import numpy as np
 import pytest
 import sympy as sym
+import sympy.physics.mechanics as me
 
 import pycollo
 
@@ -21,10 +22,10 @@ class TestHypersensitiveProblem:
     @pytest.fixture(autouse=True)
     def ocp_fixture(self):
         """Instantiate the required symbols."""
-        self.x = sym.Symbol("x")
-        self.y = sym.Symbol("y")
-        self.v = sym.Symbol("v")
-        self.u = sym.Symbol("u")
+        self.x = me.dynamicsymbols("x")
+        self.y = me.dynamicsymbols("y")
+        self.v = me.dynamicsymbols("v")
+        self.u = me.dynamicsymbols("u")
 
         self.g = 9.81
         self.t0 = 0

--- a/tests/unit/test_phase.py
+++ b/tests/unit/test_phase.py
@@ -1,6 +1,10 @@
 """Tests for the :class:`Phase` class."""
 
+from collections import namedtuple
+
 import pytest
+import sympy as sm
+import sympy.physics.mechanics as me
 
 import pycollo
 
@@ -32,3 +36,183 @@ def test_var_attrs(problem_with_phase_fixture):
     assert hasattr(phase, "_y_eqn_user")
     assert hasattr(phase, "_c_con_user")
     assert hasattr(phase, "_q_fnc_user")
+
+
+class TestPhaseStateVariables:
+    """Tests for the `Phase.state_variables` property attribute."""
+
+    @pytest.fixture(autouse=True)
+    def _ocp_with_phase_fixture(self) -> None:
+        """Simple fixture setting up an :obj:`OptimalControlProblem`."""
+        self.problem = pycollo.OptimalControlProblem(name="Fixture")
+        self.phase = self.problem.new_phase(name="A")
+        self.sm_x, self.sm_y, self.sm_v, self.sm_u = sm.symbols("x, y, v, u")
+        self.me_x, self.me_y, self.me_v, self.me_u = me.dynamicsymbols("x, y, v, u")
+
+    def test_single_sympy_symbol(self):
+        """A single `sm.Symbol` can be set."""
+        self.phase.state_variables = self.sm_x
+        assert len(self.phase.state_variables) == 1
+        assert hasattr(self.phase.state_variables, "x")
+        assert self.phase.state_variables.x == self.sm_x
+
+    def test_many_sympy_symbols(self):
+        """Multiple `sm.Symbol`s can be set."""
+        self.phase.state_variables = [self.sm_x, self.sm_y, self.sm_v]
+        assert len(self.phase.state_variables) == 3
+        assert hasattr(self.phase.state_variables, "x")
+        assert hasattr(self.phase.state_variables, "y")
+        assert hasattr(self.phase.state_variables, "v")
+        assert self.phase.state_variables.x == self.sm_x
+        assert self.phase.state_variables.y == self.sm_y
+        assert self.phase.state_variables.v == self.sm_v
+
+    def test_single_sympy_dynamics_symbol(self):
+        """A single `me.dynamicsymbols` can be set."""
+        self.phase.state_variables = self.me_x
+        assert len(self.phase.state_variables) == 1
+        assert hasattr(self.phase.state_variables, "x")
+        assert self.phase.state_variables.x == self.me_x
+
+    def test_many_sympy_dynamics_symbols(self):
+        """Multiple `me.dynamicsymbols` can be set."""
+        self.phase.state_variables = [self.me_x, self.me_y, self.me_v]
+        assert len(self.phase.state_variables) == 3
+        assert hasattr(self.phase.state_variables, "x")
+        assert hasattr(self.phase.state_variables, "y")
+        assert hasattr(self.phase.state_variables, "v")
+        assert self.phase.state_variables.x == self.me_x
+        assert self.phase.state_variables.y == self.me_y
+        assert self.phase.state_variables.v == self.me_v
+
+    def test_many_mixed_sympy_symbols_and_sympy_dynamics_symbols(self):
+        """`sm.Symbol`s and `me.dynamicsymbols` can be mixed."""
+        self.phase.state_variables = [self.me_x, self.sm_y, self.me_v]
+        assert len(self.phase.state_variables) == 3
+        assert hasattr(self.phase.state_variables, "x")
+        assert hasattr(self.phase.state_variables, "y")
+        assert hasattr(self.phase.state_variables, "v")
+        assert self.phase.state_variables.x == self.me_x
+        assert self.phase.state_variables.y == self.sm_y
+        assert self.phase.state_variables.v == self.me_v
+
+    def test_none(self):
+        """`None` causes the property attribute to be set as an empty `tuple`."""
+        self.phase.state_variables = None
+        assert self.phase.state_variables == ()
+
+    @pytest.mark.parametrize(
+        "state_variables",
+        [
+            True,
+            [sm.Symbol("x"), True, False, None],
+            [True, False, 1]
+        ]
+    )
+    def test_invalid_value(self, state_variables):
+        """A `ValueError` is raised for a invalid state variables."""
+        with pytest.raises(ValueError):
+            self.phase.state_variables = state_variables
+
+    @pytest.mark.parametrize(
+        "state_variables",
+        [
+            [sm.Symbol("x"), sm.Symbol("x")],
+            [me.dynamicsymbols("x"), me.dynamicsymbols("x")],
+            [sm.Symbol("x"), me.dynamicsymbols("x")],
+        ]
+    )
+    def test_repeated(self, state_variables):
+        """A `ValueError` is raised for repeated state variables."""
+        with pytest.raises(ValueError):
+            self.phase.state_variables = state_variables
+
+
+class TestPhaseControlVariables:
+    """Tests for the `Phase.control_variables` property attribute."""
+
+    @pytest.fixture(autouse=True)
+    def _ocp_with_phase_fixture(self) -> None:
+        """Simple fixture setting up an empty :obj:`OptimalControlProblem`."""
+        self.problem = pycollo.OptimalControlProblem(name="Fixture")
+        self.phase = self.problem.new_phase(name="A")
+        self.sm_x, self.sm_y, self.sm_v, self.sm_u = sm.symbols("x, y, v, u")
+        self.me_x, self.me_y, self.me_v, self.me_u = me.dynamicsymbols("x, y, v, u")
+
+    def test_single_sympy_symbol(self):
+        """A single `sm.Symbol` can be set."""
+        self.phase.control_variables = self.sm_x
+        assert len(self.phase.control_variables) == 1
+        assert hasattr(self.phase.control_variables, "x")
+        assert self.phase.control_variables.x == self.sm_x
+
+    def test_many_sympy_symbols(self):
+        """Multiple `sm.Symbol`s can be set."""
+        self.phase.control_variables = [self.sm_x, self.sm_y, self.sm_v]
+        assert len(self.phase.control_variables) == 3
+        assert hasattr(self.phase.control_variables, "x")
+        assert hasattr(self.phase.control_variables, "y")
+        assert hasattr(self.phase.control_variables, "v")
+        assert self.phase.control_variables.x == self.sm_x
+        assert self.phase.control_variables.y == self.sm_y
+        assert self.phase.control_variables.v == self.sm_v
+
+    def test_single_sympy_dynamics_symbol(self):
+        """A single `me.dynamicsymbols` can be set."""
+        self.phase.control_variables = self.me_x
+        assert len(self.phase.control_variables) == 1
+        assert hasattr(self.phase.control_variables, "x")
+        assert self.phase.control_variables.x == self.me_x
+
+    def test_many_sympy_dynamics_symbols(self):
+        """Multiple `me.dynamicsymbols` can be set."""
+        self.phase.control_variables = [self.me_x, self.me_y, self.me_v]
+        assert len(self.phase.control_variables) == 3
+        assert hasattr(self.phase.control_variables, "x")
+        assert hasattr(self.phase.control_variables, "y")
+        assert hasattr(self.phase.control_variables, "v")
+        assert self.phase.control_variables.x == self.me_x
+        assert self.phase.control_variables.y == self.me_y
+        assert self.phase.control_variables.v == self.me_v
+
+    def test_many_mixed_sympy_symbols_and_sympy_dynamics_symbols(self):
+        """`sm.Symbol`s and `me.dynamicsymbols` can be mixed."""
+        self.phase.control_variables = [self.me_x, self.sm_y, self.me_v]
+        assert len(self.phase.control_variables) == 3
+        assert hasattr(self.phase.control_variables, "x")
+        assert hasattr(self.phase.control_variables, "y")
+        assert hasattr(self.phase.control_variables, "v")
+        assert self.phase.control_variables.x == self.me_x
+        assert self.phase.control_variables.y == self.sm_y
+        assert self.phase.control_variables.v == self.me_v
+
+    def test_none(self):
+        """`None` causes the property attribute to be set as an empty `tuple`."""
+        self.phase.control_variables = None
+        assert self.phase.control_variables == ()
+
+    @pytest.mark.parametrize(
+        "control_variables",
+        [
+            True,
+            [sm.Symbol("x"), True, False, None],
+            [True, False, 1]
+        ]
+    )
+    def test_invalid_value(self, control_variables):
+        """A `ValueError` is raised for a invalid control variables."""
+        with pytest.raises(ValueError):
+            self.phase.control_variables = control_variables
+
+    @pytest.mark.parametrize(
+        "control_variables",
+        [
+            [sm.Symbol("x"), sm.Symbol("x")],
+            [me.dynamicsymbols("x"), me.dynamicsymbols("x")],
+            [sm.Symbol("x"), me.dynamicsymbols("x")],
+        ]
+    )
+    def test_repeated(self, control_variables):
+        """A `ValueError` is raised for repeated control variables."""
+        with pytest.raises(ValueError):
+            self.phase.control_variables = control_variables

--- a/tests/unit/test_phase.py
+++ b/tests/unit/test_phase.py
@@ -1,7 +1,5 @@
 """Tests for the :class:`Phase` class."""
 
-from collections import namedtuple
-
 import pytest
 import sympy as sm
 import sympy.physics.mechanics as me


### PR DESCRIPTION
This PR adds support for using `sympy.physics.mechanics.dynamicsymbols` as state and control variables in OCP definitions.

Using the Brachistochrone problem as an example, the single-phase OCP's state and control variables can be set using `sympy.physics.mechanics.dynamicsymbols` like:
```python
import sympy.physics.mechanics as me

import pycollo

x, y, v, u = me.dynamicsymbols("x y v u")

problem = pycollo.OptimalControlProblem(name="Brachistochrone")
phase = problem.new_phase(name="A")

# `phase.state_variables` will return a `collections.namedtuple` of length 3 where the fields are the symbol names
phase.state_variables = [x, y, v]
assert len(phase.state_variables) == 3
assert hasattr(phase.state_variables, "x")
assert hasattr(phase.state_variables, "y")
assert hasattr(phase.state_variables, "v")
assert phase.state_variables.x == x
assert phase.state_variables.y == y
assert phase.state_variables.v == v

# `phase.control_variables` will return a `collections.namedtuple` of length 1 where the field is the symbol name
phase.control_variables = u
assert len(phase.control_variables) == 1
assert hasattr(phase.control_variables, "u")
assert phase.control_variables.u == u
```

Note that the `(t)` portion of a `me.dynamicsymbols`'s name is trimmed off in the `collections.namedtuple`'s field name because this is an invalid identifier.

It's possible to mix `sm.Symbol`s with `me.dynamicsymbols` unless their names clash. For example, the following is invalid:
```python
import sympy as sm
import sympy.physics.mechanics as me

import pycollo

sm_x = sm.Symbol("x")
me_x = me.dynamicsymbols("x")

problem = pycollo.OptimalControlProblem(name="Symbol name clash")
phase = problem.new_phase(name="A")

# Will raise a `ValueError` because both `sm_x` and `me_x` are identifier as `x` (even though `me_x`'s name is `x(t)`)
phase.state_variables = [sm_x, me_x]
```