### PR TITLE
Fix GitHub Actions workflows for documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           make -C docs html
       - name: Init new repo in dist folder and commit generated files
         run: |
-          cd docs/build/html/
+          cd docs/_build/html/
           git init
           touch .nojekyll
           git add -A
@@ -40,4 +40,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           force: true
-          directory: ./docs/build/html
+          directory: ./docs/_build/html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-            python-version: '3.10'
+          python-version: '3.10'
       - name: Install dependencies
         run: python -m pip install --upgrade -r docs/requirements.txt
       - name: Build documentation with Sphinx

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
-        run: python -m pip install --upgrade -r docs/requirements.txt
+        run: python -m pip install --upgrade -r requirements.txt -r docs/requirements.txt
+      - name: Install Pycollo
+        run: python -m pip install .
       - name: Build documentation with Sphinx
         run: |
           make -C docs clean

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Build documentation with Sphinx
         run: |
             make -C docs clean
-            make -C docs -nWT -b dummy
+            make -C docs html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
-        run: python -m pip install --upgrade -r docs/requirements.txt
+        run: python -m pip install --upgrade -r requirements.txt -r docs/requirements.txt
+      - name: Install Pycollo
+        run: python -m pip install .
       - name: Build documentation with Sphinx
         run: |
           make -C docs clean

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
-        run: python -m pip install --upgrade -r requirements.txt -r docs/requirements.txt
-      - name: Install Pycollo
-        run: python -m pip install .
+        run: python -m pip install --upgrade -r docs/requirements.txt
       - name: Build documentation with Sphinx
         run: |
           make -C docs clean

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-            python-version: '3.10'
+          python-version: '3.10'
       - name: Install dependencies
         run: python -m pip install --upgrade -r docs/requirements.txt
       - name: Build documentation with Sphinx
         run: |
-            make -C docs clean
-            make -C docs html
+          make -C docs clean
+          make -C docs html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,11 +3,12 @@
 For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
-import os
+import pathlib
 import sys
 
 # Add source folder to path for autodoc
-sys.path.insert(0, os.path.abspath(".."))
+path = pathlib.Path(__file__).parent.parent.absolute()
+sys.path.insert(0, path)
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ import sys
 
 # Add source folder to path for autodoc
 path = pathlib.Path(__file__).parent.parent.absolute()
-sys.path.insert(0, path)
+sys.path.insert(0, str(path))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information


### PR DESCRIPTION
The autodoc extension for Sphinx requires the package to be discoverable. The current use of `os` and `sys` was not successful when running the `make` commands with the `-C` flag (running from outside the `docs` directory).